### PR TITLE
github command patch

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -90,7 +90,7 @@ class Bot < Summer::Connection
   end
 
   def github_command(sender, reply_to, msg, opts={})
-    parts = msg.split(" ")
+    parts = msg.split(/\/| /)
     if parts.empty?
       message = "http://github.com - Social code hosting using Git"
     else


### PR DESCRIPTION
Allow the github command to allow slashes as a separator:

!github radar railsbot
!github radar/railsbot
