### PR TITLE
Fix for a trailing '/' when only passing a username to !github.

### DIFF
--- a/bot.rb
+++ b/bot.rb
@@ -99,7 +99,8 @@ class Bot < Summer::Connection
     if parts.empty?
       message = "http://github.com - Social code hosting using Git"
     else
-      message = "http://github.com/#{parts[0]}/#{parts[1]}/"
+      message = "http://github.com/#{parts[0]}/"
+      message += "#{parts[1]}/" if parts[1]
       message += "tree/#{parts[2]}" if parts[2]
       message += "/#{parts[3..-1].join("/")}" if !parts[3].nil?
     end


### PR DESCRIPTION
Before:

```
!github davidcelis
# => https://github.com/davidcelis//
```

After:

```
!github davidcelis
# => https://github.com/davidcelis/
```

Signed-off-by: David Celis david@davidcelis.com
